### PR TITLE
Upgrade to .net framework 4.5.2

### DIFF
--- a/PrecisionGazeMouse/PrecisionGazeMouse.csproj
+++ b/PrecisionGazeMouse/PrecisionGazeMouse.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PrecisionGazeMouse</RootNamespace>
     <AssemblyName>PrecisionGazeMouse</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <NuGetPackageImportStamp>

--- a/Unity-TrackIR-Plugin-DLL-master/TrackIRUnity.csproj
+++ b/Unity-TrackIR-Plugin-DLL-master/TrackIRUnity.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>TrackIRUnity</AssemblyName>
     <ApplicationVersion>1.0.0.0</ApplicationVersion>
     <RootNamespace>TrackIRUnity</RootNamespace>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <UpgradeBackupLocation>


### PR DESCRIPTION
It seems to be impossible to download .net framework 4.5 on its own (https://dotnet.microsoft.com/download/visual-studio-sdks is the page that Visual Studio 2017 directs me to in order to download v4.5, but it isn't available on there) so let's upgrade to 4.5.2 so that other developers who do not yet have it installed (such as myself! :) ) can contribute to this project.

(Alternatively we could upgrade to the latest version of .net framework - I am not a .net developer normally, so I'm not a hundred percent certain of the consequences of that.)