### PR TITLE
Fix state management on startup (plus other fixes)

### DIFF
--- a/PrecisionGazeMouse/PrecisionGazeMouseForm.Designer.cs
+++ b/PrecisionGazeMouse/PrecisionGazeMouseForm.Designer.cs
@@ -45,19 +45,20 @@
             // PositionLabel
             // 
             this.PositionLabel.AutoSize = true;
-            this.PositionLabel.Location = new System.Drawing.Point(146, 358);
+            this.PositionLabel.Location = new System.Drawing.Point(97, 233);
+            this.PositionLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.PositionLabel.Name = "PositionLabel";
-            this.PositionLabel.Size = new System.Drawing.Size(45, 20);
+            this.PositionLabel.Size = new System.Drawing.Size(31, 13);
             this.PositionLabel.TabIndex = 8;
             this.PositionLabel.Text = "(0, 0)";
             // 
             // QuitButton
             // 
-            this.QuitButton.Location = new System.Drawing.Point(170, 442);
-            this.QuitButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.QuitButton.Location = new System.Drawing.Point(113, 287);
+            this.QuitButton.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.QuitButton.Name = "QuitButton";
-            this.QuitButton.Size = new System.Drawing.Size(84, 29);
-            this.QuitButton.TabIndex = 9;
+            this.QuitButton.Size = new System.Drawing.Size(56, 19);
+            this.QuitButton.TabIndex = 10;
             this.QuitButton.Text = "Quit";
             this.QuitButton.UseVisualStyleBackColor = true;
             this.QuitButton.Click += new System.EventHandler(this.QuitButton_Click);
@@ -65,81 +66,90 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(27, 358);
+            this.label1.Location = new System.Drawing.Point(18, 233);
+            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(108, 20);
+            this.label1.Size = new System.Drawing.Size(72, 13);
             this.label1.TabIndex = 10;
             this.label1.Text = "Gaze Position";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(24, 395);
+            this.label2.Location = new System.Drawing.Point(16, 257);
+            this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(113, 20);
+            this.label2.Size = new System.Drawing.Size(76, 13);
             this.label2.TabIndex = 11;
             this.label2.Text = "Head Rotation";
             // 
             // HeadRotationLabel
             // 
             this.HeadRotationLabel.AutoSize = true;
-            this.HeadRotationLabel.Location = new System.Drawing.Point(146, 395);
+            this.HeadRotationLabel.Location = new System.Drawing.Point(97, 257);
+            this.HeadRotationLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.HeadRotationLabel.Name = "HeadRotationLabel";
-            this.HeadRotationLabel.Size = new System.Drawing.Size(45, 20);
+            this.HeadRotationLabel.Size = new System.Drawing.Size(31, 13);
             this.HeadRotationLabel.TabIndex = 12;
             this.HeadRotationLabel.Text = "(0, 0)";
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(78, 322);
+            this.label3.Location = new System.Drawing.Point(52, 209);
+            this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(56, 20);
+            this.label3.Size = new System.Drawing.Size(37, 13);
             this.label3.TabIndex = 13;
             this.label3.Text = "Status";
             // 
             // StatusLabel
             // 
             this.StatusLabel.AutoSize = true;
-            this.StatusLabel.Location = new System.Drawing.Point(146, 322);
+            this.StatusLabel.Location = new System.Drawing.Point(97, 209);
+            this.StatusLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.StatusLabel.Name = "StatusLabel";
-            this.StatusLabel.Size = new System.Drawing.Size(65, 20);
+            this.StatusLabel.Size = new System.Drawing.Size(43, 13);
             this.StatusLabel.TabIndex = 14;
             this.StatusLabel.Text = "Starting";
             // 
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(25, 25);
+            this.label5.Location = new System.Drawing.Point(17, 16);
+            this.label5.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(106, 20);
+            this.label5.Size = new System.Drawing.Size(74, 13);
             this.label5.TabIndex = 17;
             this.label5.Text = "Tracker Mode";
             // 
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(51, 71);
+            this.label4.Location = new System.Drawing.Point(34, 46);
+            this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(83, 20);
+            this.label4.Size = new System.Drawing.Size(57, 13);
             this.label4.TabIndex = 22;
             this.label4.Text = "Movement";
             // 
             // label7
             // 
             this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(56, 260);
+            this.label7.Location = new System.Drawing.Point(37, 169);
+            this.label7.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(79, 20);
+            this.label7.Size = new System.Drawing.Size(54, 13);
             this.label7.TabIndex = 27;
             this.label7.Text = "Sensitivity";
             // 
             // ClickOnKey
             // 
             this.ClickOnKey.AutoSize = true;
-            this.ClickOnKey.Location = new System.Drawing.Point(38, 158);
+            this.ClickOnKey.Location = new System.Drawing.Point(25, 103);
+            this.ClickOnKey.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.ClickOnKey.Name = "ClickOnKey";
-            this.ClickOnKey.Size = new System.Drawing.Size(97, 20);
+            this.ClickOnKey.Size = new System.Drawing.Size(68, 13);
             this.ClickOnKey.TabIndex = 28;
             this.ClickOnKey.Text = "Click On Key";
             // 
@@ -152,54 +162,55 @@
             // PauseOnKey
             // 
             this.PauseOnKey.AutoSize = true;
-            this.PauseOnKey.Location = new System.Drawing.Point(29, 205);
+            this.PauseOnKey.Location = new System.Drawing.Point(19, 133);
+            this.PauseOnKey.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.PauseOnKey.Name = "PauseOnKey";
-            this.PauseOnKey.Size = new System.Drawing.Size(109, 20);
+            this.PauseOnKey.Size = new System.Drawing.Size(75, 13);
             this.PauseOnKey.TabIndex = 30;
             this.PauseOnKey.Text = "Pause On Key";
             // 
             // PauseOnKeyInput
             // 
             this.PauseOnKeyInput.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::PrecisionGazeMouse.Properties.Settings.Default, "PauseOnKey", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.PauseOnKeyInput.Location = new System.Drawing.Point(146, 202);
-            this.PauseOnKeyInput.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.PauseOnKeyInput.Location = new System.Drawing.Point(97, 131);
+            this.PauseOnKeyInput.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.PauseOnKeyInput.Name = "PauseOnKeyInput";
-            this.PauseOnKeyInput.Size = new System.Drawing.Size(114, 26);
-            this.PauseOnKeyInput.TabIndex = 31;
+            this.PauseOnKeyInput.Size = new System.Drawing.Size(77, 20);
+            this.PauseOnKeyInput.TabIndex = 6;
             this.PauseOnKeyInput.Text = global::PrecisionGazeMouse.Properties.Settings.Default.PauseOnKey;
             this.PauseOnKeyInput.KeyDown += new System.Windows.Forms.KeyEventHandler(this.PauseOnKeyInput_KeyDown);
             // 
             // ClickOnKeyInput
             // 
             this.ClickOnKeyInput.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::PrecisionGazeMouse.Properties.Settings.Default, "ClickOnKey", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.ClickOnKeyInput.Location = new System.Drawing.Point(148, 155);
-            this.ClickOnKeyInput.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.ClickOnKeyInput.Location = new System.Drawing.Point(99, 101);
+            this.ClickOnKeyInput.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.ClickOnKeyInput.Name = "ClickOnKeyInput";
-            this.ClickOnKeyInput.Size = new System.Drawing.Size(112, 26);
-            this.ClickOnKeyInput.TabIndex = 29;
+            this.ClickOnKeyInput.Size = new System.Drawing.Size(76, 20);
+            this.ClickOnKeyInput.TabIndex = 5;
             this.ClickOnKeyInput.Text = global::PrecisionGazeMouse.Properties.Settings.Default.ClickOnKey;
             this.ClickOnKeyInput.KeyDown += new System.Windows.Forms.KeyEventHandler(this.OnClickKeyPressInput_KeyDown);
             // 
             // SensitivityInput
             // 
             this.SensitivityInput.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::PrecisionGazeMouse.Properties.Settings.Default, "Sensitivity", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.SensitivityInput.Location = new System.Drawing.Point(142, 249);
-            this.SensitivityInput.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.SensitivityInput.Location = new System.Drawing.Point(95, 162);
+            this.SensitivityInput.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.SensitivityInput.Maximum = 20;
             this.SensitivityInput.Name = "SensitivityInput";
-            this.SensitivityInput.Size = new System.Drawing.Size(302, 69);
-            this.SensitivityInput.TabIndex = 26;
+            this.SensitivityInput.Size = new System.Drawing.Size(201, 45);
+            this.SensitivityInput.TabIndex = 7;
             this.SensitivityInput.Value = global::PrecisionGazeMouse.Properties.Settings.Default.Sensitivity;
             this.SensitivityInput.Scroll += new System.EventHandler(this.SensitivityInput_Scroll);
             // 
             // MovementOnKeyPressInput
             // 
             this.MovementOnKeyPressInput.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::PrecisionGazeMouse.Properties.Settings.Default, "MovementKey", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.MovementOnKeyPressInput.Location = new System.Drawing.Point(288, 105);
-            this.MovementOnKeyPressInput.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.MovementOnKeyPressInput.Location = new System.Drawing.Point(192, 68);
+            this.MovementOnKeyPressInput.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.MovementOnKeyPressInput.Name = "MovementOnKeyPressInput";
-            this.MovementOnKeyPressInput.Size = new System.Drawing.Size(112, 26);
-            this.MovementOnKeyPressInput.TabIndex = 25;
+            this.MovementOnKeyPressInput.Size = new System.Drawing.Size(76, 20);
+            this.MovementOnKeyPressInput.TabIndex = 4;
             this.MovementOnKeyPressInput.Text = global::PrecisionGazeMouse.Properties.Settings.Default.MovementKey;
             this.MovementOnKeyPressInput.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MovementOnKeyPressButton_Click);
             // 
@@ -208,11 +219,11 @@
             this.OnKeyPressButton.AutoSize = true;
             this.OnKeyPressButton.Checked = global::PrecisionGazeMouse.Properties.Settings.Default.OnKeyPressMovement;
             this.OnKeyPressButton.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::PrecisionGazeMouse.Properties.Settings.Default, "OnKeyPressMovement", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.OnKeyPressButton.Location = new System.Drawing.Point(148, 105);
-            this.OnKeyPressButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.OnKeyPressButton.Location = new System.Drawing.Point(99, 68);
+            this.OnKeyPressButton.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.OnKeyPressButton.Name = "OnKeyPressButton";
-            this.OnKeyPressButton.Size = new System.Drawing.Size(129, 24);
-            this.OnKeyPressButton.TabIndex = 24;
+            this.OnKeyPressButton.Size = new System.Drawing.Size(89, 17);
+            this.OnKeyPressButton.TabIndex = 3;
             this.OnKeyPressButton.TabStop = true;
             this.OnKeyPressButton.Text = "On Key Press";
             this.OnKeyPressButton.UseVisualStyleBackColor = true;
@@ -223,11 +234,11 @@
             this.ContinuousButton.AutoSize = true;
             this.ContinuousButton.Checked = global::PrecisionGazeMouse.Properties.Settings.Default.ContinuousMovement;
             this.ContinuousButton.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::PrecisionGazeMouse.Properties.Settings.Default, "ContinuousMovement", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.ContinuousButton.Location = new System.Drawing.Point(148, 71);
-            this.ContinuousButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.ContinuousButton.Location = new System.Drawing.Point(99, 46);
+            this.ContinuousButton.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.ContinuousButton.Name = "ContinuousButton";
-            this.ContinuousButton.Size = new System.Drawing.Size(115, 24);
-            this.ContinuousButton.TabIndex = 23;
+            this.ContinuousButton.Size = new System.Drawing.Size(78, 17);
+            this.ContinuousButton.TabIndex = 2;
             this.ContinuousButton.Text = "Continuous";
             this.ContinuousButton.UseVisualStyleBackColor = true;
             this.ContinuousButton.Click += new System.EventHandler(this.ContinuousButton_Click);
@@ -237,11 +248,11 @@
             this.gazeTracker.AutoSize = true;
             this.gazeTracker.Checked = global::PrecisionGazeMouse.Properties.Settings.Default.ShowGazeTracker;
             this.gazeTracker.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::PrecisionGazeMouse.Properties.Settings.Default, "ShowGazeTracker", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.gazeTracker.Location = new System.Drawing.Point(268, 356);
-            this.gazeTracker.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.gazeTracker.Location = new System.Drawing.Point(179, 231);
+            this.gazeTracker.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.gazeTracker.Name = "gazeTracker";
-            this.gazeTracker.Size = new System.Drawing.Size(175, 24);
-            this.gazeTracker.TabIndex = 21;
+            this.gazeTracker.Size = new System.Drawing.Size(121, 17);
+            this.gazeTracker.TabIndex = 9;
             this.gazeTracker.Text = "Show Gaze Tracker";
             this.gazeTracker.UseVisualStyleBackColor = true;
             this.gazeTracker.CheckedChanged += new System.EventHandler(this.gazeTracker_CheckedChanged);
@@ -251,11 +262,11 @@
             this.warpBar.AutoSize = true;
             this.warpBar.Checked = global::PrecisionGazeMouse.Properties.Settings.Default.ShowWarpBar;
             this.warpBar.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::PrecisionGazeMouse.Properties.Settings.Default, "ShowWarpBar", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.warpBar.Location = new System.Drawing.Point(268, 322);
-            this.warpBar.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.warpBar.Location = new System.Drawing.Point(179, 209);
+            this.warpBar.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.warpBar.Name = "warpBar";
-            this.warpBar.Size = new System.Drawing.Size(146, 24);
-            this.warpBar.TabIndex = 20;
+            this.warpBar.Size = new System.Drawing.Size(101, 17);
+            this.warpBar.TabIndex = 8;
             this.warpBar.Text = "Show Warp Bar";
             this.warpBar.UseVisualStyleBackColor = true;
             this.warpBar.CheckedChanged += new System.EventHandler(this.warpBar_CheckedChanged);
@@ -272,19 +283,19 @@
             "EyeX Only",
             "TrackIR Only",
             "eViacam Only"});
-            this.ModeBox.Location = new System.Drawing.Point(148, 22);
-            this.ModeBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.ModeBox.Location = new System.Drawing.Point(99, 14);
+            this.ModeBox.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.ModeBox.Name = "ModeBox";
-            this.ModeBox.Size = new System.Drawing.Size(294, 28);
-            this.ModeBox.TabIndex = 18;
+            this.ModeBox.Size = new System.Drawing.Size(197, 21);
+            this.ModeBox.TabIndex = 1;
             this.ModeBox.Text = global::PrecisionGazeMouse.Properties.Settings.Default.TrackerMode;
             this.ModeBox.SelectedIndexChanged += new System.EventHandler(this.ModeBox_SelectedIndexChanged);
             // 
             // PrecisionGazeMouseForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(468, 496);
+            this.ClientSize = new System.Drawing.Size(312, 322);
             this.Controls.Add(this.PauseOnKeyInput);
             this.Controls.Add(this.PauseOnKey);
             this.Controls.Add(this.ClickOnKeyInput);
@@ -308,11 +319,9 @@
             this.Controls.Add(this.PositionLabel);
             this.DoubleBuffered = true;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.Name = "PrecisionGazeMouseForm";
             this.Text = "Precision Gaze Mouse";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.PrecisionGazeMouseForm_FormClosing);
-            this.Shown += new System.EventHandler(this.PrecisionGazeMouseForm_Shown);
             this.Resize += new System.EventHandler(this.PrecisionGazeMouseForm_Resize);
             ((System.ComponentModel.ISupportInitialize)(this.SensitivityInput)).EndInit();
             this.ResumeLayout(false);

--- a/PrecisionGazeMouse/PrecisionGazeMouseForm.cs
+++ b/PrecisionGazeMouse/PrecisionGazeMouseForm.cs
@@ -254,6 +254,9 @@ namespace PrecisionGazeMouse
         private void OnKeyPressButton_Click(object sender, EventArgs e)
         {
             ChooseHotkeyMovement();
+
+            if (ModeBox.SelectedItem.ToString() == "EyeX and eViacam")
+                eViacamPrompt(false);
         }
 
         private void ChooseHotkeyMovement()
@@ -262,14 +265,14 @@ namespace PrecisionGazeMouse
             OnKeyPressButton.Checked = true;
 
             controller.setMovement(MouseController.Movement.HOTKEY);
-
-            if (ModeBox.SelectedItem.ToString() == "EyeX and eViacam")
-                eViacamPrompt(false);
         }
 
         private void ContinuousButton_Click(object sender, EventArgs e)
         {
             ChooseContinuousMovement();
+
+            if (ModeBox.SelectedItem.ToString() == "EyeX and eViacam")
+                eViacamPrompt(true);
         }
 
         private void ChooseContinuousMovement()
@@ -278,9 +281,6 @@ namespace PrecisionGazeMouse
             OnKeyPressButton.Checked = false;
 
             controller.setMovement(MouseController.Movement.CONTINUOUS);
-
-            if (ModeBox.SelectedItem.ToString() == "EyeX and eViacam")
-                eViacamPrompt(true);
         }
 
         private void OnClickKeyPressInput_KeyDown(object sender, KeyEventArgs e)

--- a/PrecisionGazeMouse/PrecisionPointers/NoPrecisionPointer.cs
+++ b/PrecisionGazeMouse/PrecisionPointers/NoPrecisionPointer.cs
@@ -22,7 +22,7 @@ namespace PrecisionGazeMouse.PrecisionPointers
 
         public override String ToString()
         {
-            return "";
+            return "None";
         }
 
         public bool IsStarted()

--- a/PrecisionGazeMouse/Properties/Settings.Designer.cs
+++ b/PrecisionGazeMouse/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace PrecisionGazeMouse.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.7.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/PrecisionGazeMouse/WarpPointers/NoWarpPointer.cs
+++ b/PrecisionGazeMouse/WarpPointers/NoWarpPointer.cs
@@ -37,7 +37,7 @@ namespace PrecisionGazeMouse.WarpPointers
 
         public override String ToString()
         {
-            return String.Format("({0:0}, {1:0})", warpPoint.X, warpPoint.Y);
+            return String.Format("None ({0:0}, {1:0})", warpPoint.X, warpPoint.Y);
         }
 
         public Point GetGazePoint()


### PR DESCRIPTION
There are quite a few changes in this commit, so I'll just list them out
clearly - it should be clear which lines correspond to which
fixes/changes. (Normally I try to do separate commits for separate
changes, but things got a little out of hand here, sorry!)

Fix bug: PrecisionGazeMouse no longer ignores the previous mode setting
when starting (previously it did, and you had to explicitly select the
mode again).

Fix bug: PrecisionGazeMouse no longer ignores the continuous/onkey
setting when starting (again, previously it did, and it had to be
reselected each startup).

Refactor: Remove reference to main form from MouseController class by
passing a pointer to the function to set the mouse cursor; this makes
the code a bit easier to understand.

Fix bug: PrecisionGazeMouse no longer prompts about eViaCam when
loading into a mode which does not use eViaCam.

Refactor: DRY up logging for state changes in MouseController, and add
same logging for changes in movement mechanism (continuous/onkey).

Fix bug: Tabbing between controls in the main form now works as expected
(tab indexes are set from left to right, top to bottom).

Fix bug: choosing "Continuous" or "On Key" movement radio boxes now
checks the selected radio box (previously the selection would take
effect but the UI would not update).

Behavior change: UI now shows "none" for precision/warp pointers when
the no-op pointers are selected, rather than empty string or the last
coordinates.

Extraneous change: Visual Studio form designer decided to change the
recorded sizings of a bunch of controls. In practice this doesn't seem
to have made a difference (form still looks identical), but I can't see
an easy way to undo this so I'm leaving it as is. Maybe this is a
difference between Visual Studio versions? Or due to different display
DPI settings? Who knows.