### PR TITLE
Use Enum name "None" instead of empty string to prevent crash

### DIFF
--- a/PrecisionGazeMouse/PrecisionGazeMouseForm.cs
+++ b/PrecisionGazeMouse/PrecisionGazeMouseForm.cs
@@ -288,7 +288,7 @@ namespace PrecisionGazeMouse
             e.SuppressKeyPress = true;
             if (e.KeyCode.Equals(Keys.Escape) || e.KeyCode.Equals(Keys.Back))
             {
-                ClickOnKeyInput.Text = "";
+                ClickOnKeyInput.Text = "None";
                 clickHotKey = 0;
             }
             else
@@ -331,7 +331,7 @@ namespace PrecisionGazeMouse
             e.SuppressKeyPress = true;
             if (e.KeyCode.Equals(Keys.Escape) || e.KeyCode.Equals(Keys.Back))
             {
-                PauseOnKeyInput.Text = "";
+                PauseOnKeyInput.Text = "None";
                 pauseHotKey = 0;
             }
             else


### PR DESCRIPTION
Fixes: https://github.com/PrecisionGazeMouse/PrecisionGazeMouse/issues/46